### PR TITLE
Add oUF Runebar Changes

### DIFF
--- a/units/player.lua
+++ b/units/player.lua
@@ -469,7 +469,9 @@ local create = function(self)
                     ClassPower[i]:SetPoint('TOPLEFT', ClassPower[i-1], "TOPRIGHT", 1, 0)
                 end
             end
-
+            
+            Runes.colorSpec = true
+            Runes.sortOrder = 'asc'
             self.ClassPower = ClassPower
         end
     end

--- a/units/player.lua
+++ b/units/player.lua
@@ -66,7 +66,7 @@ local create = function(self)
         s:SetPoint("BOTTOM", self, "BOTTOM", 0, 0)
         s.frequentUpdates = true
 
-        local h = CreateFrame("Frame", nil, s, BackdropTemplateMixin and "BackdropTemplate" )
+        local h = CreateFrame("Frame", nil, s, BackdropTemplateMixin and "BackdropTemplate")
         h:SetFrameLevel(0)
         h:SetPoint("TOPLEFT", -4, 4)
         h:SetPoint("BOTTOMRIGHT", 4, -4)

--- a/units/player.lua
+++ b/units/player.lua
@@ -469,7 +469,7 @@ local create = function(self)
                     ClassPower[i]:SetPoint('TOPLEFT', ClassPower[i-1], "TOPRIGHT", 1, 0)
                 end
             end
-            
+
             Runes.colorSpec = true
             Runes.sortOrder = 'asc'
             self.ClassPower = ClassPower


### PR DESCRIPTION
A few versions back, oUF added the ability to color runes by specialization and to sort them based of their status (ready to use -> charging -> depleted). This pull request enables those features.

It should be noted that runes are not colored at present and remain grey for all specs.

Thanks!